### PR TITLE
Upgrade of unit GpStuff

### DIFF
--- a/OtlOptions.inc
+++ b/OtlOptions.inc
@@ -107,7 +107,7 @@
 // INSTRUCTIONS:
 //   You can control parameters to your build process either by editing this file,
 //  or by leaving all the configuration block conditionals undefined in this file
-//  and controling them instead in the project options. The latter approach is
+//  and controlling them instead in the project options. The latter approach is
 //  better if you want config-specific settings.
 //  If controlling via this file: To turn a parameter ON, change or ensure the
 //  respective directive from
@@ -124,20 +124,19 @@
 //                               |  structure, such as TGp4AlignedInt. This     |
 //                               |  conditional only has effect for non-windows |
 //                               |  platforms and only for compilers XE7+.      |
-//                               |  This is an experiemental setting with less  |
+//                               |  This is an experimental setting with less  |
 //                               |  testing. Use at your own risk. If it works  |
 //                               |  it is likely to confer an advantage of      |
 //                               |  slightly superior performance.              |
-//  OTL_CACHE_SLACKSPACE_OFFSETS | If undefined, the TGp4AlignedInt and similiar| OFF (undefined).
-//                               |  slack-space containers recalculate the slack|
-//                               |  space offset on each value access. If set,  |
-//                               |  the offset calculation is cached, which     |
-//                               |  should give a slighly superior performance. |
 //
 // ACTUATION:
 
      {.$DEFINE OTL_RELY_ON_ALIGN}
-     {.$DEFINE OTL_CACHE_SLACKSPACE_OFFSETS}
+
+// INHERITED CONFIGURATION BLOCK
+
+     {$INCLUDE src\Gp.inc}  // Defines OTL_CACHE_SLACKSPACE_OFFSETS
+
 
 // -----------------------------------------------------------------------------
 // --------------- END OF CONFIGURATION BLOCK ----------------------------------
@@ -150,12 +149,11 @@
 
 // Post configuration block. Do not change. This section is for computed
 //  conditionals that are a function of paremeters in the configuration block.
-
-{$UNDEFINE OTL_USE_ALIGN}
-{$IFNDEF WINDOWS}
+{$UNDEF OTL_USE_ALIGN}
+{$IFNDEF MSWINDOWS}
   {$IF CompilerVersion >= 28} // XE7+
     {$IFDEF OTL_RELY_ON_ALIGN}
       {$DEFINE OTL_USE_ALIGN}
-    {$IFEND}
+    {$ENDIF}
   {$IFEND}
-{$IFEND}
+{$ENDIF}

--- a/src/Gp.inc
+++ b/src/Gp.inc
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------------
+// --------------- CONFIGURATION BLOCK -----------------------------------------
+// -----------------------------------------------------------------------------
+// INSTRUCTIONS:
+//   You can control parameters to your build process either by editing this file,
+//  or by leaving all the configuration block conditionals undefined in this file
+//  and controlling them instead in the project options. The latter approach is
+//  better if you want config-specific settings.
+//  If controlling via this file: To turn a parameter ON, change or ensure the
+//  respective directive from
+//   {.$DEFINE XXX} to {$DEFINE XXX}
+//  To turn the parameter OFF, change or ensure it is the other way around.
+//
+// PARAMETER DESCRIPTION TABLE:
+// Conditional                   | Significance                                 |  Default and recommended value
+// ..............................+..............................................+................................
+//  OTL_CACHE_SLACKSPACE_OFFSETS | If undefined, the TGp4AlignedInt and similar | OFF (undefined).
+//                               |  slack-space containers recalculate the slack|
+//                               |  space offset on each value access. If set,  |
+//                               |  the offset calculation is cached, which     |
+//                               |  should give a slightly superior performance.|
+//
+// ACTUATION:
+
+     {.$DEFINE OTL_CACHE_SLACKSPACE_OFFSETS}
+
+// -----------------------------------------------------------------------------
+// --------------- END OF CONFIGURATION BLOCK ----------------------------------
+// -----------------------------------------------------------------------------
+
+{$IFDEF CONDITIONALEXPRESSIONS}
+  {$IF CompilerVersion >= 24}
+    {$DEFINE XE3_OR_ABOVE}
+  {$IFEND}
+{$ENDIF}

--- a/src/GpStuff.pas
+++ b/src/GpStuff.pas
@@ -203,7 +203,7 @@ type
 
   public
     {$IFDEF OTL_CACHE_SLACKSPACE_OFFSETS}
-      procedure Initiate;
+      procedure Initialize;
     {$ENDIF}
     function  Add(value: integer): integer; inline;
     function  Addr: PInteger; inline;
@@ -239,7 +239,7 @@ type
     procedure SetValue(value: int64); inline;
   public
     {$IFDEF OTL_CACHE_SLACKSPACE_OFFSETS}
-      procedure Initiate;
+      procedure Initialize;
     {$ENDIF}
     function  Add(value: int64): int64; inline;
     function  Addr: PInt64; inline;
@@ -1134,7 +1134,7 @@ end; { DebugBreak }
 {$IFDEF GpStuff_AlignedInt}
 
 {$IFDEF OTL_CACHE_SLACKSPACE_OFFSETS}
-  procedure TGp4AlignedInt.Initiate;
+  procedure TGp4AlignedInt.Initialize;
   begin
     FAddr := PInteger((NativeInt(@aiData) + 3) AND NOT 3)
   end;
@@ -1319,7 +1319,7 @@ end; { TGp4AlignedInt.Subtract }
 
 
 {$IFDEF OTL_CACHE_SLACKSPACE_OFFSETS}
-  procedure TGp8AlignedInt64.Initiate;
+  procedure TGp8AlignedInt64.Initialize;
   begin
     Assert(SizeOf(pointer) = SizeOf(NativeInt));
     FAddr := PInt64((NativeInt(@aiData) + 7) AND NOT 7);
@@ -1403,9 +1403,9 @@ begin
   Result := DSiInterlockedIncrement64(Addr^);
   {$ELSE}
     {$IFDEF OTL_CACHE_SLACKSPACE_OFFSETS}
-    result := TInterlocked.Add( FAddr^, value)
+    result := TInterlocked.Increment( FAddr^)
     {$ELSE}
-    result := TInterlocked.Add( Addr^, value)
+    result := TInterlocked.Increment( Addr^)
     {$ENDIF}
   {$ENDIF}
 end; { TGp8AlignedInt64.Increment }


### PR DESCRIPTION
1. Corrected error (WINDOWS-->MSWINDOWS) and
  spelling mistakes in OtlOptions.inc
2. Added Gp.inc
3. Extended GpStuff.pas to support non-windows
4. Adjust string handling to support zero-based strings and future compilers
5. Optional support for caching address calculations in TGp4AlignedInt/TGp8AlignedInt64. Caution: These records now require the client to call Initiate() after allocation.