### PR TITLE
Suggestions and findings from FixInsight

### DIFF
--- a/OtlCommon.pas
+++ b/OtlCommon.pas
@@ -586,7 +586,7 @@ type
     procedure Grow(requiredIdx: integer = -1);
   public
     constructor Create;
-    procedure Add(const paramValue: TOmniValue; paramName: string = '');
+    procedure Add(const paramValue: TOmniValue; const paramName: string = '');
     procedure Assign(const parameters: array of TOmniValue);
     procedure AssignNamed(const parameters: array of TOmniValue);
     function  ByName(const paramName: string): TOmniValue; overload;
@@ -1304,7 +1304,7 @@ begin
   ovcCount := 0;
 end; { TOmniValueContainer.Create }
 
-procedure TOmniValueContainer.Add(const paramValue: TOmniValue; paramName: string);
+procedure TOmniValueContainer.Add(const paramValue: TOmniValue; const paramName: string);
 var
   idxParam: integer;
 begin

--- a/OtlTaskControl.pas
+++ b/OtlTaskControl.pas
@@ -1454,7 +1454,7 @@ var
   chainTo       : IOmniTaskControl;
   sync          : TSynchroObject;
   taskException : Exception;
-  terminateEvent: TOmniTransitionEvent;
+  terminatesEvent: TOmniTransitionEvent;
 begin
   otCleanupLock.EnterWriteLock;
   try
@@ -1464,7 +1464,7 @@ begin
   finally otCleanupLock.ExitWriteLock; end;
   otThreadID := GetThreadID;
   chainTo := nil;
-  terminateEvent := {$IFDEF MSWINDOWS}0{$ELSE}nil{$ENDIF};
+  terminatesEvent := {$IFDEF MSWINDOWS}0{$ELSE}nil{$ENDIF};
   try
     try
       try
@@ -1489,7 +1489,7 @@ begin
         then
           chainTo := otSharedInfo_ref.ChainTo;
         otSharedInfo_ref.ChainTo := nil;
-        terminateEvent := otSharedInfo_ref.TerminatedEvent;
+        terminatesEvent := otSharedInfo_ref.TerminatedEvent;
         otSharedInfo_ref.Stopped := true;
         // with internal monitoring this will not be processed if the task controller owner is also shutting down
         sync := nil; // to remove the warning in the 'finally' clause below
@@ -1510,7 +1510,7 @@ begin
       otExecutor_ref   := nil;
       otParameters_ref := nil;
       otSharedInfo_ref := nil;
-      SetEvent(terminateEvent);
+      SetEvent(terminatesEvent);
     end;
     if assigned(chainTo) then
       chainTo.Run; // TODO 1 -oPrimoz Gabrijelcic : Should InternalExecute the chained task in the same thread (should work when run in a pool)

--- a/src/DSiWin32.pas
+++ b/src/DSiWin32.pas
@@ -1254,18 +1254,18 @@ type
   function  DSiRealModuleName: string;
   function  DSiRemoveAceFromDesktop(desktop: HDESK; sid: PSID): boolean;
   function  DSiRemoveAceFromWindowStation(station: HWINSTA; sid: PSID): boolean;
-  function  DSiSetProcessAffinity(affinity: string): string;
+  function  DSiSetProcessAffinity(const affinity: string): string;
   function  DSiSetProcessPriorityClass(const processName: string;
     priority: DWORD): boolean;
-  function  DSiSetThreadAffinity(affinity: string): string;
+  function  DSiSetThreadAffinity(const affinity: string): string;
   procedure DSiStopImpersonatingUser;
-  function  DSiStringToAffinityMask(affinity: string): DSiNativeUInt;
+  function  DSiStringToAffinityMask(const affinity: string): DSiNativeUInt;
   function  DSiTerminateProcessById(processID: DWORD; closeWindowsFirst: boolean = true;
     maxWait_sec: integer = 10): boolean;
   procedure DSiTrimWorkingSet;
-  function  DSiValidateProcessAffinity(affinity: string): string;
+  function  DSiValidateProcessAffinity(const affinity: string): string;
   function  DSiValidateProcessAffinityMask(affinityMask: DSiNativeUInt): DSiNativeUInt;
-  function  DSiValidateThreadAffinity(affinity: string): string;
+  function  DSiValidateThreadAffinity(const affinity: string): string;
   function  DSiValidateThreadAffinityMask(affinityMask: DSiNativeUInt): DSiNativeUInt;
   procedure DSiYield;
 
@@ -1662,14 +1662,14 @@ type // Firewall management types
 
   function  DSiAddApplicationToFirewallExceptionList(const entryName,
     applicationFullPath: string; resolveConflict: TDSiFwResolveConflict = rcDuplicate;
-    description: string = ''; grouping: string = '';
-    serviceName: string = ''; protocols: TDSiFwIPProtocols = [fwProtoTCP];
-    localPorts: string = '*'; profiles: TDSiFwIPProfiles = [fwProfileAll]): boolean;
+    const description: string = ''; const grouping: string = '';
+    const serviceName: string = ''; protocols: TDSiFwIPProtocols = [fwProtoTCP];
+    const localPorts: string = '*'; profiles: TDSiFwIPProfiles = [fwProfileAll]): boolean;
   function  DSiAddApplicationToFirewallExceptionListAdvanced(const entryName,
     applicationFullPath: string; resolveConflict: TDSiFwResolveConflict = rcDuplicate;
-    description: string = ''; grouping: string = '';
-    serviceName: string = ''; protocols: TDSiFwIPProtocols = [fwProtoTCP];
-    localPorts: string = '*'; profiles: TDSiFwIPProfiles = [fwProfileAll]): boolean;
+    const description: string = ''; const grouping: string = '';
+    const serviceName: string = ''; protocols: TDSiFwIPProtocols = [fwProtoTCP];
+    const localPorts: string = '*'; profiles: TDSiFwIPProfiles = [fwProfileAll]): boolean;
   function  DSiAddApplicationToFirewallExceptionListXP(const entryName,
     applicationFullPath: string; resolveConflict: TDSiFwResolveConflict = rcDuplicate;
     profile: TDSiFwIPProfile = fwProfileCurrent): boolean;
@@ -2058,7 +2058,7 @@ const
     TBackgroundThread.Create(task);
   end; { CreateProcessWatchdog }
 
-  function FileOpenSafe(fileName: string; var fileHandle: textfile;
+  function FileOpenSafe(const fileName: string; var fileHandle: textfile;
     diskRetryDelay, diskRetryCount: integer): boolean;
   var
     dum: integer;
@@ -5421,7 +5421,7 @@ const
     @author  gabr
     @since   2003-11-12
   }
-  function DSiSetProcessAffinity(affinity: string): string;
+  function DSiSetProcessAffinity(const affinity: string): string;
   begin
     SetProcessAffinityMask(GetCurrentProcess,
       DSiValidateProcessAffinityMask(DSiStringToAffinityMask(affinity)));
@@ -5471,7 +5471,7 @@ const
     @author  gabr
     @since   2003-11-12
   }        
-  function DSiSetThreadAffinity(affinity: string): string;
+  function DSiSetThreadAffinity(const affinity: string): string;
   begin
     SetThreadAffinityMask(GetCurrentThread,
       DSiValidateThreadAffinityMask(DSiStringToAffinityMask(affinity)));
@@ -5490,7 +5490,7 @@ const
     @author  gabr
     @since   2003-11-14
   }        
-  function DSiStringToAffinityMask(affinity: string): DSiNativeUInt;
+  function DSiStringToAffinityMask(const affinity: string): DSiNativeUInt;
   var
     idxID: integer;
   begin
@@ -5552,7 +5552,7 @@ const
     @author  gabr
     @since   2003-11-14
   }
-  function DSiValidateProcessAffinity(affinity: string): string;
+  function DSiValidateProcessAffinity(const affinity: string): string;
   begin
     Result := DSiAffinityMaskToString(DSiValidateProcessAffinityMask(
                 DSiStringToAffinityMask(affinity)));
@@ -5573,7 +5573,7 @@ const
     @author  gabr
     @since   2003-11-14
   }
-  function DSiValidateThreadAffinity(affinity: string): string;
+  function DSiValidateThreadAffinity(const affinity: string): string;
   begin
     Result := DSiAffinityMaskToString(DSiValidateThreadAffinityMask(
                 DSiStringToAffinityMask(affinity)));
@@ -7138,8 +7138,8 @@ var
   }
   function DSiAddApplicationToFirewallExceptionList(const entryName,
     applicationFullPath: string; resolveConflict: TDSiFwResolveConflict;
-    description: string; grouping: string; serviceName: string;
-    protocols: TDSiFwIPProtocols; localPorts: string; profiles: TDSiFwIPProfiles): boolean;
+    const description: string; const grouping: string; const serviceName: string;
+    protocols: TDSiFwIPProtocols; const localPorts: string; profiles: TDSiFwIPProfiles): boolean;
   var
     profile    : TDSiFwIPProfile;
     versionInfo: TOSVersionInfo;
@@ -7175,8 +7175,8 @@ var
   }
   function DSiAddApplicationToFirewallExceptionListAdvanced(const entryName,
     applicationFullPath: string; resolveConflict: TDSiFwResolveConflict;
-    description: string; grouping: string; serviceName: string;
-    protocols: TDSiFwIPProtocols; localPorts: string; profiles: TDSiFwIPProfiles): boolean;
+    const description: string; const grouping: string; const serviceName: string;
+    protocols: TDSiFwIPProtocols; const localPorts: string; profiles: TDSiFwIPProfiles): boolean;
   var
     fwPolicy2  : OleVariant;
     profileMask: integer;

--- a/src/GpLists.pas
+++ b/src/GpLists.pas
@@ -2371,7 +2371,7 @@ begin
     Result := 1
   else if DWORD(guid1.D4[4]) < DWORD(guid2.D4[4]) then
     Result := -1
-  else if DWORD(guid1.D4[4]) < DWORD(guid2.D4[4]) then
+  else if DWORD(guid1.D4[4]) > DWORD(guid2.D4[4]) then
     Result := 1
   else
     Result := 0;

--- a/src/GpLists.pas
+++ b/src/GpLists.pas
@@ -352,7 +352,7 @@ type
   private
     sValue: string;
   public
-    constructor Create(aValue: string = '');
+    constructor Create(const aValue: string = '');
     property Value: string read sValue write sValue;
   end; { TGpString }
 
@@ -364,7 +364,7 @@ type
   private
     sValue: WideString;
   public
-    constructor Create(aValue: WideString = '');
+    constructor Create(const aValue: WideString = '');
     property Value: WideString read sValue write sValue;
   end; { TGpWideString }
   {$ENDIF}
@@ -1585,14 +1585,14 @@ type
     function  Add(aClass: TClass): integer;
     procedure Clear;
     procedure Delete(idx: integer);
-    function  CreateObject(sClass: string): TObject;
+    function  CreateObject(const sClass: string): TObject;
     {$IFDEF GpLists_Enumerators}
     function  GetEnumerator: TGpClassListEnumerator;
     {$ENDIF GpLists_Enumerators}
     function  IndexOf(aClass: TClass): integer; overload;
-    function  IndexOf(sClass: string): integer; overload;
+    function  IndexOf(const sClass: string): integer; overload;
     procedure Remove(aClass: TClass); overload;
-    procedure Remove(sClass: string); overload;
+    procedure Remove(const sClass: string); overload;
     property Capacity: integer read GetCapacity write SetCapacity;
     property Count: integer read GetCount;
     property Items[idx: integer]: TClass read GetItems; default;
@@ -1617,14 +1617,14 @@ type
     function  Add(aClass: TClass): integer;
     procedure Clear;                                {$IFDEF GpLists_Inline}inline;{$ENDIF}
     procedure Delete(idx: integer);                 {$IFDEF GpLists_Inline}inline;{$ENDIF}
-    function  CreateObject(sClass: string): TObject;
+    function  CreateObject(const sClass: string): TObject;
     {$IFDEF GpLists_Enumerators}
     function  GetEnumerator: TGpClassListEnumerator;{$IFDEF GpLists_Inline}inline;{$ENDIF}
     {$ENDIF GpLists_Enumerators}
     function  IndexOf(aClass: TClass): integer; overload; {$IFDEF GpLists_Inline}inline;{$ENDIF}
-    function  IndexOf(sClass: string): integer; overload; {$IFDEF GpLists_Inline}inline;{$ENDIF}
+    function  IndexOf(const sClass: string): integer; overload; {$IFDEF GpLists_Inline}inline;{$ENDIF}
     procedure Remove(aClass: TClass); overload;     {$IFDEF GpLists_Inline}inline;{$ENDIF}
-    procedure Remove(sClass: string); overload;     {$IFDEF GpLists_Inline}inline;{$ENDIF}
+    procedure Remove(const sClass: string); overload;     {$IFDEF GpLists_Inline}inline;{$ENDIF}
     property Capacity: integer read GetCapacity write SetCapacity;
     property Count: integer read GetCount;
     property Items[idx: integer]: TClass read GetItems; default;
@@ -2422,7 +2422,7 @@ end; { TGpDateTime.Create }
 
 { TGpString }
 
-constructor TGpString.Create(aValue: string);
+constructor TGpString.Create(const aValue: string);
 begin
   inherited Create;
   sValue := aValue;
@@ -2431,7 +2431,7 @@ end; { TGpString.Create }
 { TGpWideString }
 
 {$IFDEF MSWINDOWS}
-constructor TGpWideString.Create(aValue: WideString);
+constructor TGpWideString.Create(const aValue: WideString);
 begin
   inherited Create;
   sValue := aValue;
@@ -5677,7 +5677,7 @@ begin
   Result := TGpClassList.Create;
 end; { TGpClassList.CreateInterface }
 
-function TGpClassList.CreateObject(sClass: string): TObject;
+function TGpClassList.CreateObject(const sClass: string): TObject;
 var
   idxClass: integer;
 begin
@@ -5700,12 +5700,12 @@ begin
   Result := clClasses.IndexOf(aClass.ClassName);
 end; { TGpClassList.IndexOf }
 
-function TGpClassList.IndexOf(sClass: string): integer;
+function TGpClassList.IndexOf(const sClass: string): integer;
 begin
   Result := clClasses.IndexOf(sClass);
 end; { TGpClassList.IndexOf }
 
-procedure TGpClassList.Remove(sClass: string);
+procedure TGpClassList.Remove(const sClass: string);
 var
   idxItem: integer;
 begin

--- a/src/GpStuff.pas
+++ b/src/GpStuff.pas
@@ -399,7 +399,7 @@ function  Asgn(var output: AnsiString; const value: AnsiString): AnsiString; ove
 {$ENDIF Unicode}
 function  Asgn(var output: WideString; const value: WideString): WideString; overload;    {$IFDEF GpStuff_Inline}inline;{$ENDIF}
 
-function  IFF(condit: boolean; iftrue, iffalse: string): string; overload;    {$IFDEF GpStuff_Inline}inline;{$ENDIF}
+function  IFF(condit: boolean; const iftrue, iffalse: string): string; overload; {$IFDEF GpStuff_Inline}inline;{$ENDIF}
 function  IFF(condit: boolean; iftrue, iffalse: integer): integer; overload;  {$IFDEF GpStuff_Inline}inline;{$ENDIF}
 function  IFF(condit: boolean; iftrue, iffalse: real): real; overload;        {$IFDEF GpStuff_Inline}inline;{$ENDIF}
 function  IFF(condit: boolean; iftrue, iffalse: boolean): boolean; overload;  {$IFDEF GpStuff_Inline}inline;{$ENDIF}
@@ -868,7 +868,7 @@ begin
   Result := output;
 end; { Asgn64 }
 
-function IFF(condit: boolean; iftrue, iffalse: string): string;
+function IFF(condit: boolean; const iftrue, iffalse: string): string;
 begin
   if condit then
     Result := iftrue

--- a/src/HVStringBuilder.pas
+++ b/src/HVStringBuilder.pas
@@ -104,8 +104,8 @@ type
     function Remove(StartIndex: Integer; Length: Integer): StringBuilder;
     function Replace(OldChar: Char; NewChar: Char): StringBuilder; overload;
     function Replace(OldChar: Char; NewChar: Char; StartIndex: Integer; Count: Integer): StringBuilder; overload;
-    function Replace(const OldValue: String; NewValue: String): StringBuilder; overload;
-    function Replace(const OldValue: String; NewValue: String; StartIndex: Integer; Count: Integer): StringBuilder; overload;
+    function Replace(const OldValue, NewValue: String): StringBuilder; overload;
+    function Replace(const OldValue, NewValue: String; StartIndex: Integer; Count: Integer): StringBuilder; overload;
     function ToString: String; {$IF CompilerVersion >= 21}reintroduce;{$IFEND} overload;
     function ToString(StartIndex: Integer; Length: Integer): String; {$IF CompilerVersion >= 21}reintroduce;{$IFEND} overload;
     property Capacity: Integer read GetCapacity write SetCapacity;
@@ -469,7 +469,7 @@ begin
   Result := Replace(OldChar, NewChar, 0, Length);
 end;
 
-function StringBuilder.Replace(const OldValue: String; NewValue: String;
+function StringBuilder.Replace(const OldValue: String; const NewValue: String;
   StartIndex, Count: Integer): StringBuilder;
 begin
   Inc(StartIndex);
@@ -483,8 +483,7 @@ begin
   Result := Self;
 end;
 
-function StringBuilder.Replace(const OldValue: String;
-  NewValue: String): StringBuilder;
+function StringBuilder.Replace(const OldValue, NewValue: String): StringBuilder;
 begin
   NeedStringValue;
   // Note: StringReplace is slow


### PR DESCRIPTION
I use a tool called [FixInsight](http://sourceoddity.com/fixinsight/) in Delphi.
It can point out possible errors and optimizations in code that is hard to find otherwise.

In case of OmnithreadLibrary I found 3 things.
- Many string parameters lack const keyword. With const the compiler can make more effiecient code.
- Change name of terminateEvent to terminatesEvent. Reason is that the name is the same as an property and it is unclear priority.
- The last one was a change of a comparison operator in GuidCompare. I guess this was a simple copy & paste error.