### PR TITLE
Fix #160 Remove vcl references

### DIFF
--- a/packages/Delphi 10 Seattle/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi 10 Seattle/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi 10 Seattle/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi 10 Seattle/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi 10.1 Berlin/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi 10.1 Berlin/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi 10.1 Berlin/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi 10.1 Berlin/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>3</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -85,8 +85,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />
     <DCCReference Include="..\..\src\GpStringHash.pas" />

--- a/packages/Delphi 10.2 Tokyo/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi 10.2 Tokyo/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi 10.2 Tokyo/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi 10.2 Tokyo/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
         <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
         <Base>True</Base>
         <AppType>Package</AppType>
-        <FrameworkType>VCL</FrameworkType>
+        <FrameworkType>None</FrameworkType>
         <Platform Condition="'$(Platform)'==''">Win64</Platform>
         <TargetedPlatforms>3</TargetedPlatforms>
     </PropertyGroup>
@@ -50,7 +50,7 @@
         <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
         <VerInfo_Locale>1060</VerInfo_Locale>
         <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
         <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -94,8 +94,6 @@
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
         <DCCReference Include="rtl.dcp"/>
-        <DCCReference Include="vclx.dcp"/>
-        <DCCReference Include="vcl.dcp"/>
         <DCCReference Include="..\..\src\GpLists.pas"/>
         <DCCReference Include="..\..\src\GpStuff.pas"/>
         <DCCReference Include="..\..\src\GpStringHash.pas"/>

--- a/packages/Delphi 10.3 Rio/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi 10.3 Rio/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi 10.3 Rio/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi 10.3 Rio/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
         <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
         <Base>True</Base>
         <AppType>Package</AppType>
-        <FrameworkType>VCL</FrameworkType>
+        <FrameworkType>None</FrameworkType>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <TargetedPlatforms>3</TargetedPlatforms>
     </PropertyGroup>
@@ -50,7 +50,7 @@
         <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
         <VerInfo_Locale>1060</VerInfo_Locale>
         <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
         <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -94,8 +94,6 @@
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
         <DCCReference Include="rtl.dcp"/>
-        <DCCReference Include="vclx.dcp"/>
-        <DCCReference Include="vcl.dcp"/>
         <DCCReference Include="..\..\src\GpLists.pas"/>
         <DCCReference Include="..\..\src\GpStuff.pas"/>
         <DCCReference Include="..\..\src\GpStringHash.pas"/>

--- a/packages/Delphi 10.4 Sydney/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi 10.4 Sydney/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi 10.4 Sydney/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi 10.4 Sydney/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
         <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
         <Base>True</Base>
         <AppType>Package</AppType>
-        <FrameworkType>VCL</FrameworkType>
+        <FrameworkType>None</FrameworkType>
         <Platform Condition="'$(Platform)'==''">Win32</Platform>
         <TargetedPlatforms>3</TargetedPlatforms>
     </PropertyGroup>
@@ -50,7 +50,7 @@
         <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-        <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
         <VerInfo_Locale>1060</VerInfo_Locale>
         <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
         <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -95,8 +95,6 @@
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
         <DCCReference Include="rtl.dcp"/>
-        <DCCReference Include="vclx.dcp"/>
-        <DCCReference Include="vcl.dcp"/>
         <DCCReference Include="..\..\src\GpLists.pas"/>
         <DCCReference Include="..\..\src\GpStuff.pas"/>
         <DCCReference Include="..\..\src\GpStringHash.pas"/>

--- a/packages/Delphi 2007/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi 2007/OmniThreadLibraryRuntime.dpk
@@ -28,9 +28,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi 2007/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi 2007/OmniThreadLibraryRuntime.dproj
@@ -72,7 +72,5 @@
     <DCCReference Include="..\..\src\HVStringBuilder.pas" />
     <DCCReference Include="..\..\src\HVStringData.pas" />
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vcl.dcp" />
-    <DCCReference Include="vclx.dcp" />
   </ItemGroup>
 </Project>

--- a/packages/Delphi 2009/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi 2009/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi 2009/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi 2009/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi 2010/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi 2010/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi 2010/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi 2010/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi XE/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi XE/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi XE/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi XE/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi XE2/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi XE2/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi XE2/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi XE2/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi XE3/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi XE3/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi XE3/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi XE3/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi XE4/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi XE4/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi XE4/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi XE4/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi XE5/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi XE5/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi XE5/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi XE5/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi XE6/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi XE6/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi XE6/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi XE6/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi XE7/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi XE7/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi XE7/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi XE7/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />

--- a/packages/Delphi XE8/OmniThreadLibraryRuntime.dpk
+++ b/packages/Delphi XE8/OmniThreadLibraryRuntime.dpk
@@ -31,9 +31,7 @@ package OmniThreadLibraryRuntime;
 {$IMPLICITBUILD ON}
 
 requires
-  rtl,
-  vclx,
-  vcl;
+  rtl;
 
 contains
   GpLists in '..\..\src\GpLists.pas',

--- a/packages/Delphi XE8/OmniThreadLibraryRuntime.dproj
+++ b/packages/Delphi XE8/OmniThreadLibraryRuntime.dproj
@@ -7,7 +7,7 @@
     <DCC_DCCCompiler>DCC32</DCC_DCCCompiler>
     <Base>True</Base>
     <AppType>Package</AppType>
-    <FrameworkType>VCL</FrameworkType>
+    <FrameworkType>None</FrameworkType>
     <Platform Condition="'$(Platform)'==''">Win32</Platform>
     <TargetedPlatforms>1</TargetedPlatforms>
   </PropertyGroup>
@@ -44,7 +44,7 @@
     <SanitizedProjectName>OmniThreadLibraryRuntime</SanitizedProjectName>
     <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
     <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
-    <DCC_Namespace>Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
+    <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Winapi;System.Win;$(DCC_Namespace)</DCC_Namespace>
     <VerInfo_Locale>1060</VerInfo_Locale>
     <DCC_Description>OmniThreadLibrary runtime</DCC_Description>
     <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
@@ -86,8 +86,6 @@
       <MainSource>MainSource</MainSource>
     </DelphiCompile>
     <DCCReference Include="rtl.dcp" />
-    <DCCReference Include="vclx.dcp" />
-    <DCCReference Include="vcl.dcp" />
     <DCCReference Include="OmniThreadLibraryRuntime.dcp" />
     <DCCReference Include="..\..\src\GpLists.pas" />
     <DCCReference Include="..\..\src\GpStuff.pas" />


### PR DESCRIPTION
Minor change but important for server applications that use runtime packages and do not reference the VCL (also important for docker support).