### PR TITLE
Fixed couple small typos

### DIFF
--- a/OtlContainers.pas
+++ b/OtlContainers.pas
@@ -108,7 +108,7 @@ unit OtlContainers;
 {$ENDIF ~CPUX64}
 //DEFINE DEBUG_OMNI_QUEUE to enable assertions in TOmniBaseQueue
 
-//We don't have a platform-independant way of using cmpx8b/cmpx16b
+//We don't have a platform-independent way of using cmpx8b/cmpx16b
 //(5-parameter OtlSync.CAS) so we can't use bus-locking on non-Windows targets.
 {$IFDEF MSWINDOWS}
   {$DEFINE OTL_HaveCmpx16b}
@@ -1140,7 +1140,7 @@ end; { TOmniBoundedQueue.Enqueue }
 //Bus-locking queue implementation.
 //On non-Windows platforms same memory layout is used, but synchronisation
 //is achieved using a critical section, not with bus-locking because we
-//don't have a platform-independant equivalent of cmpx8b/cmpx16b.
+//don't have a platform-independent equivalent of cmpx8b/cmpx16b.
 
 (*
 TOmniQueue

--- a/OtlThreadPool.pas
+++ b/OtlThreadPool.pas
@@ -542,7 +542,7 @@ type
   // invoked from TOmniThreadPool
     procedure Cancel(const params: TOmniValue);
     procedure CancelAll(const params: TOmniValue);
-    procedure MaintainanceTimer;
+    procedure MainteinanceTimer;
   end; { TOTPWorker }
 
   TOTPThreadDataFactoryData = class
@@ -1151,7 +1151,7 @@ begin
   owStoppingWorkers := TObjectList.Create(false);
   owWorkItemQueue := TObjectList.Create(false);
   CountQueued.Value := 0;
-  Task.SetTimer(1, 1000, @TOTPWorker.MaintainanceTimer);
+  Task.SetTimer(1, 1000, @TOTPWorker.MainteinanceTimer);
   UpdateScheduler;
   Result := true;
 end; { TOTPWorker.Initialize }
@@ -1230,7 +1230,7 @@ begin
   {$ENDIF LogThreadPool}
 end; { TOTPWorker.Log }
 
-procedure TOTPWorker.MaintainanceTimer;
+procedure TOTPWorker.MainteinanceTimer;
 var
   iWorker: integer;
   worker : TOTPWorkerThread;
@@ -1293,7 +1293,7 @@ begin
     else
       Inc(iWorker);
   end;
-end; { TOTPWorker.MaintainanceTimer }
+end; { TOTPWorker.MainteinanceTimer }
 
 procedure TOTPWorker.CheckIdleQueue;
 var


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request addresses typographical errors in OtlContainers.pas and OtlThreadPool.pas. It corrects the spelling of 'platform-independent' in comments and standardizes timer method naming for consistency throughout the codebase, improving documentation clarity and maintainability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>