### PR TITLE
Fix: AV in TOmniParallelLoopBase.InternalExecute when taskFinalizer is not provided.

### DIFF
--- a/OtlParallel.pas
+++ b/OtlParallel.pas
@@ -2592,7 +2592,8 @@ begin
       taskState : TOmniValue;
       value     : TOmniValue;
     begin
-      FTaskInitializer(taskState);
+      if Assigned(FTaskInitializer) then
+        FTaskInitializer(taskState);
       try
         localQueue := FDataManager.CreateLocalQueue;
         try

--- a/OtlParallel.pas
+++ b/OtlParallel.pas
@@ -2599,7 +2599,7 @@ begin
           while (not Stopped) and localQueue.GetNext(value) do
             loopBody(task, value, taskState);
         finally FreeAndNil(localQueue); end;
-      finally FTaskFinalizer(taskState); end;
+      finally if Assigned(FTaskFinalizer) then FTaskFinalizer(taskState); end;
     end
   );
 end; { TOmniParallelLoopBase.InternalExecute }

--- a/OtlParallel.pas
+++ b/OtlParallel.pas
@@ -2599,7 +2599,10 @@ begin
           while (not Stopped) and localQueue.GetNext(value) do
             loopBody(task, value, taskState);
         finally FreeAndNil(localQueue); end;
-      finally if Assigned(FTaskFinalizer) then FTaskFinalizer(taskState); end;
+      finally 
+        if Assigned(FTaskFinalizer) then 
+          FTaskFinalizer(taskState); 
+      end;
     end
   );
 end; { TOmniParallelLoopBase.InternalExecute }


### PR DESCRIPTION
Check if FTaskInitializer and FTaskFinalizer are assigned before calling in TOmniParallelLoopBase.InternalExecute.  This correlates to the way the TOmniBackgroundWorker.BackgroundWorker works.