### PR TITLE
Prevent "Variable might not have been initialized" warning.

### DIFF
--- a/src/GpStuff.pas
+++ b/src/GpStuff.pas
@@ -2705,6 +2705,9 @@ begin
     cndWritten      : when := 1;
     cndReadOrWritten: when := 3;
     cndExecuted     : when := 0;
+  else
+    when := 0;
+    Assert(False);
   end;
   ctx.Dr7 := ctx.Dr7 AND NOT (3 SHL 8) OR (1 SHL 8);
   ctx.Dr7 := ctx.Dr7 AND NOT (3 SHL (16 + (idx - 1) * 4)) OR (when SHL (16 + (idx - 1) * 4));
@@ -2713,6 +2716,9 @@ begin
     sz2B: size := 1;
     sz4B: size := 3;
     sz8B: size := 2;
+  else
+    size := 0;
+    Assert(False);
   end;
   ctx.Dr7 := ctx.Dr7 AND NOT (3 SHL (16 + (idx - 1) * 4 + 2)) OR (size SHL (16 + (idx - 1) * 4 + 2));
   if      idx = 1 then ctx.Dr0 := NativeUInt(address)
@@ -3509,4 +3515,5 @@ end; { _.Assign<T> }
 initialization
   GDisableDebugBreak := false;
 end.
+
 


### PR DESCRIPTION
Prevent "Variable 'size' might not have been initialized" warning. 
Prevent "Variable 'when' might not have been initialized" warning.

When project is build with strict compiler rules (Variable might not have been initialized=Error) , it does not compile at all. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes compilation issues by explicitly initializing previously uninitialized variables. It adds else blocks with Assert(False) statements in src/GpStuff.pas to ensure all code paths are covered. These changes properly handle 'when' and 'size' variables under strict compiler rules, with minor formatting improvements.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>