### PR TITLE
Used Signed and unsigned types, should be fixed now

### DIFF
--- a/src/DSiWin32.pas
+++ b/src/DSiWin32.pas
@@ -5899,7 +5899,7 @@ type
   }
   function  DSiGetSystemECoreAffinityMask: DSiNativeUInt;
   var
-    bit      : integer;
+    bit      : DSiNativeUInt;
     info     : TSystemLogicalProcessorInformationExArr;
     iProcInfo: integer;
   begin
@@ -5929,7 +5929,7 @@ type
   }
   function  DSiGetSystemPCoreAffinityMask: DSiNativeUInt;
   var
-    bit      : integer;
+    bit      : DSiNativeUInt;
     info     : TSystemLogicalProcessorInformationExArr;
     iProcInfo: integer;
   begin


### PR DESCRIPTION
Fixed compiler WARNINGS: W1024 Combining signed and unsigned types - widened both operands 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request modifies variable types in the DSiWin32.pas file to ensure compatibility and prevent potential issues related to signed and unsigned types.</li>

<li>The changes enhance type safety by aligning the data types used in the functions.</li>

<li>Compiler warnings related to type usage are addressed.</li>

<li>Overall, this pull request touches on type safety and code quality improvements, introducing potential issues if not properly managed.</li>

</ul>

</div>