### PR TITLE
Optimizations (Redone because previous PR had conflicts)

### DIFF
--- a/OtlCommon.pas
+++ b/OtlCommon.pas
@@ -530,7 +530,7 @@ type
     property OwnsObject: boolean read IsOwnedObject write SetOwnsObject;
   {$IFDEF MSWINDOWS}
     function  CastToAnsiStringDef(const defValue: AnsiString): AnsiString; inline;
-    function  CastToWideStringDef(defValue: WideString): WideString; inline;
+    function  CastToWideStringDef(const defValue: WideString): WideString; inline;
     function  IsAnsiString: boolean; inline;
     function  IsWideString: boolean; inline;
     function  TryCastToAnsiString(var value: AnsiString): boolean;
@@ -1621,13 +1621,6 @@ begin
   ovcCount := 0;
 end; { TOmniValueContainer.Create }
 
-procedure TOmniValueContainer.Clear; //inline
-begin
-  SetLength(ovcNames, 0);
-  SetLength(ovcValues, 0);
-  ovcCount := 0;
-end; { TOmniValueContainer.Clear }
-
 procedure TOmniValueContainer.Add(const paramValue: TOmniValue; const paramName: string);
 var
   idxParam: integer;
@@ -1651,6 +1644,13 @@ begin
     Grow;
   ovcNames[Result] := paramName;
 end; { TOmniValueContainer.AddParam }
+
+procedure TOmniValueContainer.Clear; //inline
+begin
+  SetLength(ovcNames, 0);
+  SetLength(ovcValues, 0);
+  ovcCount := 0;
+end; { TOmniValueContainer.Clear }
 
 procedure TOmniValueContainer.Assign(const parameters: array of TOmniValue);
 var
@@ -2938,7 +2938,7 @@ begin
     raise Exception.Create('TOmniValue cannot be converted to WideString');
 end; { TOmniValue.CastToWideString }
 
-function TOmniValue.CastToWideStringDef(defValue: WideString): WideString;
+function TOmniValue.CastToWideStringDef(const defValue: WideString): WideString;
 begin
   if not TryCastToWideString(Result) then
     Result := defValue;
@@ -3043,7 +3043,6 @@ const
   CBoolStr: array [boolean] of string = ('F', 'T');
 var
   arr: TOmniValueContainer;
-  autoDestroy: IOmniAutoDestroyObject;
   i: integer;
   maxItems: integer;
   obj: TObject;

--- a/OtlSync.pas
+++ b/OtlSync.pas
@@ -1778,6 +1778,14 @@ end; { TLightweightMREWEx.TryBeginWrite }
 
 { Locked<T> }
 
+procedure Locked<T>.Clear;
+begin
+  FLifecycle := nil;
+  FInitialized := false;
+  FValue := Default(T);
+  FOwnsObject := false;
+end; { Locked }
+
 constructor Locked<T>.Create(const value: T; ownsObject: boolean);
 begin
   {$IFDEF OTL_HasLightweightMREW}
@@ -1850,14 +1858,6 @@ begin
 end; { Locked<T>.BeginWrite }
 {$ENDIF OTL_HasLightweightMREW}
 
-procedure Locked<T>.Clear;
-begin
-  FLifecycle := nil;
-  FInitialized := false;
-  FValue := Default(T);
-  FOwnsObject := false;
-end; { Locked }
-
 {$IFDEF OTL_HasLightweightMREW}
 procedure Locked<T>.EndRead;
 begin
@@ -1881,6 +1881,23 @@ begin
   Acquire;
   Result := FValue;
 end; { Locked<T>.Enter }
+
+procedure Locked<T>.Leave;
+begin
+  {$IFDEF OTL_HasLightweightMREW}
+  FLock.EndWrite;
+  {$ELSE ~OTL_HasLightweightMREW}
+  FLock.Release;
+  {$ENDIF ~OTL_HasLightweightMREW}
+  {$IFDEF DEBUG}
+  FLockCount.Decrement;
+  {$ENDIF DEBUG}
+end; { Locked<T>.Leave }
+
+procedure Locked<T>.Release;
+begin
+  Leave;
+end; { Locked<T>.Release }
 
 procedure Locked<T>.Free;
 begin
@@ -1971,18 +1988,6 @@ begin
 end; { Locked<T>.Initialize }
 {$ENDIF OTL_ERTTI}
 
-procedure Locked<T>.Leave;
-begin
-  {$IFDEF OTL_HasLightweightMREW}
-  FLock.EndWrite;
-  {$ELSE ~OTL_HasLightweightMREW}
-  FLock.Release;
-  {$ENDIF ~OTL_HasLightweightMREW}
-  {$IFDEF DEBUG}
-  FLockCount.Decrement;
-  {$ENDIF DEBUG}
-end; { Locked<T>.Leave }
-
 procedure Locked<T>.Locked(proc: TProc);
 begin
   Acquire;
@@ -1998,11 +2003,6 @@ begin
     proc(Value);
   finally Release; end;
 end; { Locked<T>.Locked }
-
-procedure Locked<T>.Release;
-begin
-  Leave;
-end; { Locked<T>.Release }
 
 {$IFDEF OTL_HasLightweightMREW}
 function Locked<T>.TryBeginRead: boolean;

--- a/src/DSiWin32.pas
+++ b/src/DSiWin32.pas
@@ -1459,7 +1459,7 @@ type
     const workDir: string = ''; wait: boolean = false;
     startInfo: PStartupInfo = nil): cardinal; overload;
   function  DSiExecuteInSession(sessionID: DWORD; const commandLine: string;
-    var processInfo: TProcessInformation; workDir: string = ''): boolean;
+    var processInfo: TProcessInformation; const workDir: string = ''): boolean;
   function  DSiGetProcessAffinity: string;
   function  DSiGetProcessAffinityMask: DSiNativeUInt;
   function  DSiGetProcessID(const processName: string; var processID: DWORD): boolean;
@@ -5398,7 +5398,7 @@ type
              specified or 0 in other cases.
   }
   function  DSiExecuteInSession(sessionID: DWORD; const commandLine: string;
-    var processInfo: TProcessInformation; workDir: string): boolean;
+    var processInfo: TProcessInformation; const workDir: string): boolean;
   var
     cmdLine : string;
     hToken  : THandle;

--- a/src/DetailedRTTI.pas
+++ b/src/DetailedRTTI.pas
@@ -41,7 +41,7 @@ type
     function RTTIMethodsAsString: string;
   end;
 
-  function DescriptionOfMethod( Obj: TObject; MethodName: string ): string;
+  function DescriptionOfMethod( Obj: TObject; const MethodName: string ): string;
 
   {$ENDIF HAS_RECORDHELPERS}
 implementation
@@ -62,7 +62,7 @@ const
 
 {$IFDEF HAS_RECORDHELPERS}
 
-function DescriptionOfMethod( Obj: TObject; MethodName: string ): string;
+function DescriptionOfMethod( Obj: TObject; const MethodName: string ): string;
 var
   header: PMethodInfoHeader;
   headerEnd: Pointer;

--- a/src/GpLists.pas
+++ b/src/GpLists.pas
@@ -8181,6 +8181,11 @@ begin
   Initialize;
 end; { TGpSkipList }
 
+function TGpSkipList<T,K>.GetKey(const el: T): K;
+begin
+  Result := FGetKey(el);
+end; { TGpSkipList<T,K> }
+
 function TGpSkipList<T,K>.Compare(const key: K; el: TGpSkipListEl<T>): integer;
 begin
   Result := Compare(key, GetKey(el.Element));
@@ -8312,11 +8317,6 @@ function TGpSkipList<T,K>.GetEnumerator: TGpSkipListEnumerator<T>;
 begin
   Result := TGpSkipListEnumerator<T>.Create(FHead, FTail);
 end; { TGpSkipList }
-
-function TGpSkipList<T,K>.GetKey(const el: T): K;
-begin
-  Result := FGetKey(el);
-end; { TGpSkipList<T,K> }
 
 procedure TGpSkipList<T, K>.Initialize;
 var

--- a/src/GpStuff.pas
+++ b/src/GpStuff.pas
@@ -723,7 +723,7 @@ function  IFF(condit: boolean; iftrue, iffalse: TDateTime): TDateTime; overload;
 function  IFF64(condit: boolean; iftrue, iffalse: int64): int64;              {$IFDEF GpStuff_Inline}inline;{$ENDIF}
 {$IFDEF MSWINDOWS}
 {$IFDEF Unicode}
-function  IFF(condit: boolean; iftrue, iffalse: AnsiString): AnsiString; overload;    {$IFDEF GpStuff_Inline}inline;{$ENDIF}
+function  IFF(condit: boolean; const iftrue, iffalse: AnsiString): AnsiString; overload;    {$IFDEF GpStuff_Inline}inline;{$ENDIF}
 {$ENDIF Unicode}
 {$ENDIF MSWINDOWS}
 
@@ -949,7 +949,7 @@ function IndexOfListA(const value: AnsiString; const values: array of AnsiString
 {$IFDEF GpStuff_TArrayOfT}
 function LinearMap(value: real; const x, y: TArray<real>): real;
 
-function SplitList(const aList: string; delim: string; const quoteChar: string = '';
+function SplitList(const aList: string; const delim: string; const quoteChar: string = '';
   stripQuotes: boolean = true): TArray<string>; overload;
 function SplitList(const aList: string; delim: TSysCharSet; const quoteChar: string = '';
   stripQuotes: boolean = true): TArray<string>; overload;
@@ -1200,7 +1200,7 @@ end; { AutoExecute }
 {$ENDIF GpStuff_Anonymous}
 
 //copied from GpString unit
-procedure GetDelimiters(const list: string; delim: string; const quoteChar: string;
+procedure GetDelimiters(const list: string; const delim: string; const quoteChar: string;
   addTerminators: boolean; var delimiters: TDelimiters); overload;
 var
   chk   : boolean;
@@ -1405,7 +1405,7 @@ end; { IFF64 }
 
 {$IFDEF MSWINDOWS}
 {$IFDEF Unicode}
-function IFF(condit: boolean; iftrue, iffalse: AnsiString): AnsiString;
+function IFF(condit: boolean; const iftrue, iffalse: AnsiString): AnsiString;
 begin
   if condit then
     Result := iftrue
@@ -1505,6 +1505,26 @@ begin
     end; //with
   end; //for i
 end; { OpenArrayToVarArray }
+
+procedure OutputDebugString(const msg: string);
+begin
+{$IFDEF MSWINDOWS}
+{$WARN SYMBOL_PLATFORM OFF}
+  if DebugHook <> 0 then
+    Windows.OutputDebugString(PChar(msg));
+{$WARN SYMBOL_PLATFORM ON}
+{$ENDIF}
+end; { OutputDebugString }
+
+procedure OutputDebugString(const msg: string; const params: array of const);
+begin
+{$IFDEF MSWINDOWS}
+{$WARN SYMBOL_PLATFORM OFF}
+  if DebugHook <> 0 then
+    OutputDebugString(Format(msg, params));
+{$WARN SYMBOL_PLATFORM ON}
+{$ENDIF}
+end; { OutputDebugString }
 
 function FormatDataSize(value: int64): string;
 begin
@@ -2264,7 +2284,7 @@ begin
   raise Exception.Create('LinearMap: Internal error. This line should never be executed.');
 end; { LinearMap }
 
-function SplitList(const aList: string; delim: string; const quoteChar: string = '';
+function SplitList(const aList: string; const delim: string; const quoteChar: string = '';
   stripQuotes: boolean = true): TArray<string>;
 var
   delimiters: TDelimiters;
@@ -2687,26 +2707,6 @@ begin
   intf._Release;
 end; { GetRefCount }
 
-procedure OutputDebugString(const msg: string);
-begin
-{$IFDEF MSWINDOWS}
-{$WARN SYMBOL_PLATFORM OFF}
-  if DebugHook <> 0 then
-    Windows.OutputDebugString(PChar(msg));
-{$WARN SYMBOL_PLATFORM ON}
-{$ENDIF}
-end; { OutputDebugString }
-
-procedure OutputDebugString(const msg: string; const params: array of const);
-begin
-{$IFDEF MSWINDOWS}
-{$WARN SYMBOL_PLATFORM OFF}
-  if DebugHook <> 0 then
-    OutputDebugString(Format(msg, params));
-{$WARN SYMBOL_PLATFORM ON}
-{$ENDIF}
-end; { OutputDebugString }
-
 {$IFDEF GpStuff_TThread_Current}
 procedure SetDataBreakpoint(idx: TDataBreakpointIndex; address: pointer;
   condition: TDataBreakpointCondition; dataSize: TDataBreakpointDataSize);
@@ -3072,6 +3072,70 @@ end; { TGpMemoryStream.Write }
 
 { TGpBuffer }
 
+procedure TGpBuffer.Add(b: byte);
+begin
+  FData.Seek(0, soEnd);
+  FData.Write(b, 1);
+end; { TGpBuffer.Add }
+
+{$IFDEF MSWINDOWS}
+procedure TGpBuffer.Add(ch: AnsiChar);
+begin
+  Add(byte(ch));
+end; { TGpBuffer.Add }
+{$ENDIF}
+
+procedure TGpBuffer.Allocate(size: integer);
+begin
+  Assert(size >= 0);
+  FData.Size := size;
+end; { TGpBuffer.Allocate }
+
+procedure TGpBuffer.Append(data: pointer; size: integer);
+begin
+  if size > 0 then begin
+    FData.Seek(0, soEnd);
+    FData.Write(data^, size);
+  end;
+end; { TGpBuffer.Append }
+
+procedure TGpBuffer.Append(stream: TStream);
+begin
+  if stream.Size > 0 then begin
+    FData.Seek(0, soEnd);
+    AsStream.CopyFrom(stream, 0);
+  end;
+end; { TGpBuffer.Append }
+
+procedure TGpBuffer.Append(const buffer: IGpBuffer);
+begin
+  Append(buffer.Value, buffer.Size);
+end; { TGpBuffer.Append }
+
+procedure TGpBuffer.Assign(data: pointer; size: integer);
+begin
+  Allocate(size);
+  if size > 0 then
+    Move(data^, Value^, size);
+end; { TGpBuffer.Assign }
+
+procedure TGpBuffer.Assign(stream: TStream);
+begin
+  Size := 0;
+  Append(stream);
+end; { TGpBuffer.Assign }
+
+procedure TGpBuffer.Assign(const buffer: IGpBuffer);
+begin
+  Size := 0;
+  Append(buffer);
+end; { TGpBuffer.Assign }
+
+procedure TGpBuffer.Clear;
+begin
+  Allocate(0);
+end; { TGpBuffer.Clear }
+
 constructor TGpBuffer.Create;
 begin
   inherited Create;
@@ -3175,70 +3239,6 @@ class function TGpBuffer.Make: IGpBuffer;
 begin
   Result := TGpBuffer.Create;
 end; { TGpBuffer.Make }
-
-procedure TGpBuffer.Add(b: byte);
-begin
-  FData.Seek(0, soEnd);
-  FData.Write(b, 1);
-end; { TGpBuffer.Add }
-
-{$IFDEF MSWINDOWS}
-procedure TGpBuffer.Add(ch: AnsiChar);
-begin
-  Add(byte(ch));
-end; { TGpBuffer.Add }
-{$ENDIF}
-
-procedure TGpBuffer.Allocate(size: integer);
-begin
-  Assert(size >= 0);
-  FData.Size := size;
-end; { TGpBuffer.Allocate }
-
-procedure TGpBuffer.Append(data: pointer; size: integer);
-begin
-  if size > 0 then begin
-    FData.Seek(0, soEnd);
-    FData.Write(data^, size);
-  end;
-end; { TGpBuffer.Append }
-
-procedure TGpBuffer.Append(stream: TStream);
-begin
-  if stream.Size > 0 then begin
-    FData.Seek(0, soEnd);
-    AsStream.CopyFrom(stream, 0);
-  end;
-end; { TGpBuffer.Append }
-
-procedure TGpBuffer.Append(const buffer: IGpBuffer);
-begin
-  Append(buffer.Value, buffer.Size);
-end; { TGpBuffer.Append }
-
-procedure TGpBuffer.Assign(data: pointer; size: integer);
-begin
-  Allocate(size);
-  if size > 0 then
-    Move(data^, Value^, size);
-end; { TGpBuffer.Assign }
-
-procedure TGpBuffer.Assign(stream: TStream);
-begin
-  Size := 0;
-  Append(stream);
-end; { TGpBuffer.Assign }
-
-procedure TGpBuffer.Assign(const buffer: IGpBuffer);
-begin
-  Size := 0;
-  Append(buffer);
-end; { TGpBuffer.Assign }
-
-procedure TGpBuffer.Clear;
-begin
-  Allocate(0);
-end; { TGpBuffer.Clear }
 
 function TGpBuffer.Equals(const buffer: IGpBuffer): boolean;
 begin


### PR DESCRIPTION
 - inlined routines must be implemented before it used. Delphi is single pass compiler and inlining is impossible if not done so.
 - Unmodified string parameters marked as const, should be clearly fasted this way, Affect to real word usage might be negligible