### PR TITLE
Pointer math error fixed. Pointers where casted to Cardinal, and just…

### DIFF
--- a/OtlTaskControl.pas
+++ b/OtlTaskControl.pas
@@ -2555,7 +2555,7 @@ procedure TOmniTaskExecutor.GetMethodAddrAndSignature(const methodName: string; 
 const
   CShortLen = SizeOf(ShortString) - 1;
 var
-  headerEnd       : cardinal;
+  headerEnd       : NativeUInt;
   methodInfoHeader: PMethodInfoHeader;
   paramNum        : integer;
   params          : PParamInfo;
@@ -2618,14 +2618,15 @@ begin { TOmniTaskExecutor.GetMethodAddrAndSignature }
                               [WorkerIntf.Implementor.ClassName, methodName]);
   // only limited subset of method signatures is allowed:
   // (Self), (Self, const TOmniValue), (Self, var TObject)
-  headerEnd := cardinal(methodInfoHeader) + methodInfoHeader^.Len;
-  returnInfo := PReturnInfo(cardinal(methodInfoHeader) + SizeOf(methodInfoHeader^)
+  headerEnd := NativeUInt(methodInfoHeader) + methodInfoHeader^.Len;
+  returnInfo := PReturnInfo(NativeUInt(methodInfoHeader) + SizeOf(methodInfoHeader^)
             - CShortLen + Length(methodInfoHeader^.Name));
-  params := PParamInfo(cardinal(returnInfo) + SizeOf(TReturnInfo));
+  params := PParamInfo(NativeUInt(returnInfo) + SizeOf(TReturnInfo));
   paramNum := 0;
   methodSignature := itUnknown;
   // Loop over the parameters
-  while (cardinal(params) < headerEnd) do begin
+
+  while (NativeUInt(params) < headerEnd) do begin
     {$IFDEF OTL_KnowsParamCount}
     if paramNum >= returnInfo.ParamCount then
       break; //while


### PR DESCRIPTION
… started to fail on 64bit version.

 - For reason or other this was not problem before, maybe Windows update changed something to make this visible. And/OR D13.1
- More info: https://github.com/gabr42/OmniThreadLibrary/issues/218