### PR TITLE
Fix invalud pointer to integer/cardinal casts

### DIFF
--- a/OtlSync.pas
+++ b/OtlSync.pas
@@ -4,7 +4,7 @@
 ///<license>
 ///This software is distributed under the BSD license.
 ///
-///Copyright (c) 2025, Primoz Gabrijelcic
+///Copyright (c) 2020, Primoz Gabrijelcic
 ///All rights reserved.
 ///
 ///Redistribution and use in source and binary forms, with or without modification,
@@ -36,26 +36,10 @@
 ///     Blog            : http://thedelphigeek.com
 ///   Contributors      : GJ, Lee_Nover, dottor_jeckill, Sean B. Durkin, VyPu
 ///   Creation date     : 2009-03-30
-///   Last modification : 2025-11-20
-///   Version           : 2.0a
+///   Last modification : 2023-11-28
+///   Version           : 1.27d
 ///</para><para>
 ///   History:
-///     2.0a: 2025-11-20
-///       - Implemented Locked<T>.IsInitialized.
-///     2.0: 2025-11-11
-///       - Implemented TLightweightMREWEx extension to TLightweightMREW (Delphi 11+ only).
-///         This class adds support for nested BeginWrite/EndWrite calls.
-///         See https://www.thedelphigeek.com/2021/02/readers-writ-47358-48721-45511-46172.html
-///         for more information.
-///       - Implemented interface ILightweightMREWEx with the same public
-///         methods as TLightweightMREWEx and implementing class
-///         TLightweightMREWExImpl that wraps TLightweightMREWEx.
-///       - Added methods Enter: T and Leave to Locked<T>.
-///       - Added methods BeginRead, TryBeginRead, EndRead, BeginWrite,
-///         TryBeginWrite, EndWrite to Locked<T> (Delphi 11+ only).
-///       - Locked<T>.Access/Release now implement locking with a
-///         SRW lock (when available) in 'write' access mode. This is functionally
-///         identical to the old implementation (critical section).
 ///     1.27d: 2023-11-28
 ///       - Fixed hints & warnings.
 ///       - Locked<T>.Initialize without the 'factory' parameter could return
@@ -387,60 +371,6 @@ type
     {$ENDIF MSWINDOWS}
   end; { IOmniCancellationToken }
 
-  {$IFDEF OTL_HasLightweightMREW}
-  TLightweightMREWEx = record
-  private
-    FRWLock        : TLightweightMREW;
-    FWriteLockCount: TOmniAlignedInt32;
-    FLockOwner     : TThreadID;
-  private
-    function  GetLockOwner: TThreadID; inline;
-    procedure SetLockOwner(value: TThreadID); inline;
-  public
-    class operator Initialize(out dest: TLightweightMREWEx);
-    procedure BeginRead; inline;
-    function  TryBeginRead: boolean; {$IF defined(LINUX) or defined(ANDROID)}overload;{$IFEND} inline;
-    {$IF defined(LINUX) or defined(ANDROID)}
-    function  TryBeginRead(timeout: cardinal): boolean; overload; inline;
-    {$IFEND LINUX or ANDROID}
-    procedure EndRead; inline;
-    procedure BeginWrite;
-    function  TryBeginWrite: boolean; {$IF defined(LINUX) or defined(ANDROID)}overload;
-    function  TryBeginWrite(timeout: cardinal): boolean; overload;
-    {$IFEND LINUX or ANDROID}
-    procedure EndWrite;
-  end; { TLightweightMREWEx }
-
-  ILightweightMREWEx = interface
-    procedure BeginRead;
-    function  TryBeginRead: boolean; {$IF defined(LINUX) or defined(ANDROID)}overload;
-    function  TryBeginRead(timeout: cardinal): boolean; overload;
-    {$IFEND LINUX or ANDROID}
-    procedure EndRead;
-    procedure BeginWrite;
-    function  TryBeginWrite: boolean; {$IF defined(LINUX) or defined(ANDROID)}overload;
-    function  TryBeginWrite(timeout: cardinal): boolean; overload;
-    {$IFEND LINUX or ANDROID}
-    procedure EndWrite;
-  end; { ILightweightMREWEx }
-
-  TLightweightMREWExImpl = class(TInterfacedObject, ILightweightMREWEx)
-  strict private
-    FLock: TLightweightMREWEx;
-  public
-    procedure BeginRead;
-    function  TryBeginRead: boolean; {$IF defined(LINUX) or defined(ANDROID)}overload;
-    function  TryBeginRead(timeout: cardinal): boolean; overload;
-    {$IFEND LINUX or ANDROID}
-    procedure EndRead;
-    procedure BeginWrite;
-    function  TryBeginWrite: boolean; {$IF defined(LINUX) or defined(ANDROID)}overload;
-    function  TryBeginWrite(timeout: cardinal): boolean; overload;
-    {$IFEND LINUX or ANDROID}
-    procedure EndWrite;
-  end; { TLightweightMREWEx }
-  {$ENDIF OTL_HasLightweightMREW}
-
   {$IFDEF OTL_Generics}
   Atomic<T> = class
     type TFactory = reference to function: T;
@@ -458,20 +388,12 @@ type
 
   Locked<T> = record
   strict private // keep those aligned!
-    // FLock and FLockCount must be interfaces.
-    // If an instance of Locked<T> is access via property, it will bo copied.
-    // If FLock or FLockCount would be non-referenced objects, this copying
-    // would break the connection between the original Locked<T> and its copy.
-    FLock     : {$IFDEF OTL_HasLightweightMREW}ILightweightMREWEx{$ELSE}TOmniCS{$ENDIF};
-    {$IFDEF DEBUG}
-    FLockCount: IOmniCounter;
-    {$ENDIF DEBUG}
+    FLock     : TOmniCS;
     FValue    : T;
   strict private
     FInitialized: boolean;
     FLifecycle  : IInterface;
     FOwnsObject : boolean;
-    procedure AssertLocked; inline;
     procedure Clear; inline;
     function  GetValue: T; inline;
     procedure SetValue(const value: T); inline;
@@ -485,28 +407,11 @@ type
     {$IFDEF OTL_ERTTI}
     function  Initialize: T; overload;
     {$ENDIF OTL_ERTTI}
-    procedure Acquire; inline;   // acquires Write SRW lock on Delphi 11+, critical section lock on previous versions
-    procedure Release; inline;   // releases Write SRW lock on Delphi 11+, critical section lock on previous versions
-    function  Enter: T; inline;  // acquires Write SRW lock on Delphi 11+, critical section lock on previous versions
-    procedure Leave; inline;     // releases Write SRW lock on Delphi 11+, critical section lock on previous versions
+    procedure Acquire; inline;
     procedure Locked(proc: TProc); overload; inline;
     procedure Locked(proc: TProcT); overload; inline;
-
-    {$IFDEF OTL_HasLightweightMREW}
-    function  BeginRead: T; inline;
-    procedure EndRead; inline;
-    function  TryBeginRead: boolean; {$IF defined(LINUX) or defined(ANDROID)}overload;{$IFEND} inline;
-    {$IF defined(LINUX) or defined(ANDROID)}
-    function  TryBeginRead(Timeout: Cardinal): Boolean; overload; inline;
-    {$IFEND LINUX or ANDROID}
-    function  BeginWrite: T; inline;
-    procedure EndWrite; inline;
-    function  TryBeginWrite: boolean; {$IF defined(LINUX) or defined(ANDROID)}overload;
-    function  TryBeginWrite(timeout: cardinal): boolean; overload; inline;
-    {$IFEND LINUX or ANDROID}
-    {$ENDIF OTL_HasLightweightMREW}
-    procedure Free; //inline;
-    property IsInitialized: boolean read FInitialized;
+    procedure Release; inline;
+    procedure Free; inline;
     property Value: T read GetValue write SetValue;
   end; { Locked<T> }
 
@@ -1176,12 +1081,12 @@ asm
   lock  xadd [addend], value
 end; { NInterlockedExchangeAdd }
 
-{$IFNDEF OTL_HasInterlockedCompareExchangePointer}
+{.$IFNDEF OTL_HasInterlockedCompareExchangePointer}
 function InterlockedCompareExchangePointer(var destination: pointer; exchange: pointer;
   comparand: pointer): pointer;
 begin
-  Result := pointer(InterlockedCompareExchange(integer(destination), integer(exchange),
-    integer(comparand)));
+  Result := pointer(InterlockedCompareExchange(NativeUInt(destination), NativeUInt(exchange),
+    NativeUInt(comparand)));
 end; { InterlockedCompareExchangePointer }
 {$ENDIF OTL_HasInterlockedCompareExchangePointer}
 
@@ -1660,141 +1565,16 @@ end; { Atomic<I,T>.Initialize }
 
 {$ENDIF OTL_ERTTI}
 
-{$IFDEF OTL_HasLightweightMREW}
-
-{ TLightweightMREWEx }
-
-function TLightweightMREWEx.GetLockOwner: TThreadID; //inline
-begin
-  {$IFDEF DEBUG}
-  Assert(SizeOf(FLockOwner) = SizeOf(integer), 'TThreadID is no longer an integer');
-  {$ENDIF DEBUG}
-  {$IFDEF MSWINDOWS}
-  Result := InterlockedCompareExchange(integer(FLockOwner), 0, 0);
-  {$ELSE}
-  Result := TInterlocked.Read(FLockOwner);
-  {$ENDIF ~MSWINDOWS}
-end; { TLightweightMREWEx.GetLockOwner }
-
-procedure TLightweightMREWEx.SetLockOwner(value: TThreadID); //inline
-begin
-  {$IFDEF DEBUG}
-  Assert(SizeOf(FLockOwner) = SizeOf(integer), 'TThreadID is no longer an integer');
-  {$ENDIF DEBUG}
-  {$IFDEF MSWINDOWS}
-  InterlockedExchange(integer(FLockOwner), integer(value));
-  {$ELSE}
-  TInterlocked.Exchange(FLockOwner, value);
-  {$ENDIF}
-end; { TLightweightMREWEx.SetLockOwner }
-
-class operator TLightweightMREWEx.Initialize(out dest: TLightweightMREWEx);
-begin
-  Dest.SetLockOwner(0);
-  Dest.FWriteLockCount.Value := 0;
-end; { TLightweightMREWEx.Initialize }
-
-procedure TLightweightMREWEx.BeginRead;
-begin
-  FRWLock.BeginRead;
-end; { TLightweightMREWEx.BeginRead }
-
-procedure TLightweightMREWEx.BeginWrite;
-begin
-  if GetLockOwner = TThread.Current.ThreadID then
-    // We are already an owner so no need for locking.
-    // If another thread executes BeginWrite at this moment, it would enter
-    // the 'else' part below and block in the call to FRWLock.BeginWrite.
-    FWriteLockCount.Increment
-  else begin
-    FRWLock.BeginWrite;
-    SetLockOwner(TThread.Current.ThreadID);
-    FWriteLockCount.Value := 1;
-  end;
-end; { TLightweightMREWEx.BeginWrite }
-
-procedure TLightweightMREWEx.EndRead;
-begin
-  FRWLock.EndRead;
-end; { TLightweightMREWEx.EndRead }
-
-procedure TLightweightMREWEx.EndWrite;
-begin
-  if GetLockOwner <> TThread.Current.ThreadID then
-    raise Exception.Create('Not an owner');
-
-  if FWriteLockCount.Value <= 0 then
-    raise Exception.Create('Attempting to release write lock that was not acquired');
-  if FWriteLockCount.Decrement = 0 then begin
-    SetLockOwner(0);
-    FRWLock.EndWrite;
-  end;
-end; { TLightweightMREWEx.EndWrite }
-
-function TLightweightMREWEx.TryBeginRead: boolean;
-begin
-  Result := FRWLock.TryBeginRead;
-end; { TLightweightMREWEx.TryBeginRead }
-
-{$IF defined(LINUX) or defined(ANDROID)}
-function TLightweightMREWEx.TryBeginRead(timeout: cardinal): boolean;
-begin
-  Result := FRWLock.TryBeginRead(timeout);
-end; { TLightweightMREWEx.TryBeginRead }
-{$IFEND LINUX or ANDROID}
-
-function TLightweightMREWEx.TryBeginWrite: boolean;
-begin
-  if GetLockOwner = TThread.Current.ThreadID then begin
-    FWriteLockCount.Increment;
-    Result := true;
-  end
-  else begin
-    Result := FRWLock.TryBeginWrite;
-    if Result then begin
-      SetLockOwner(TThread.Current.ThreadID);
-      FWriteLockCount.Value := 1;
-    end;
-  end;
-end; { TLightweightMREWEx.TryBeginWrite }
-
-{$IF defined(LINUX) or defined(ANDROID)}
-function TLightweightMREWEx.TryBeginWrite(timeout: cardinal): boolean;
-begin
-  if GetLockOwner = TThread.Current.ThreadID then begin
-    FWriteLockCount.Increment;
-    Result := true;
-  end
-  else begin
-    Result := FRWLock.TryBeginWrite(timeout);
-    if Result then begin
-      SetLockOwner(TThread.Current.ThreadID);
-      FWriteLockCount.Value := 1;
-    end;
-  end;
-end; { TLightweightMREWEx.TryBeginWrite }
-{$IFEND LINUX or ANDROID}
-{$ENDIF OTL_HasLightweightMREW}
-
 { Locked<T> }
 
 constructor Locked<T>.Create(const value: T; ownsObject: boolean);
 begin
-  {$IFDEF OTL_HasLightweightMREW}
-  FLock := TLightweightMREWExImpl.Create;
-  {$ELSE ~OTL_HasLightweightMREW}
-  FLock.Initialize;
-  {$ENDIF ~OTL_HasLightweightMREW}
-  {$IFDEF DEBUG}
-  FLockCount := CreateCounter;
-  {$ENDIF DEBUG}
-
   Clear;
   FValue := value;
   if ownsObject and (PTypeInfo(TypeInfo(T))^.Kind = tkClass) then
     FLifecycle := CreateAutoDestroyObject(TObject(PPointer(@value)^));
-
   FInitialized := true;
+  FLock.Initialize;
 end; { Locked<T>.Create }
 
 class operator Locked<T>.Implicit(const value: Locked<T>): T;
@@ -1809,46 +1589,8 @@ end; { Locked<T>.Implicit }
 
 procedure Locked<T>.Acquire;
 begin
-  {$IFDEF OTL_HasLightweightMREW}
-  FLock.BeginWrite;
-  {$ELSE ~OTL_HasLightweightMREW}
   FLock.Acquire;
-  {$ENDIF ~OTL_HasLightweightMREW}
-  {$IFDEF DEBUG}
-  FLockCount.Increment;
-  {$ENDIF DEBUG}
 end; { Locked<T>.Acquire }
-
-procedure Locked<T>.AssertLocked;
-begin
-  // This is just a debugging helper. It catches most bad cases of accessing
-  // Locked<T>.Value while Locked<T> is not locked. It may fail (not detect a problem)
-  // in multithreading code where one thread may lock the Locked<T> and
-  // then another thread tries to access Locked<T>.Value.
-  {$IFDEF DEBUG}
-  Assert(FLockCount.Value > 0, 'Locked<T> is not locked!');
-  {$ENDIF DEBUG}
-end; { Locked<T>.AssertLocked }
-
-{$IFDEF OTL_HasLightweightMREW}
-function Locked<T>.BeginRead: T;
-begin
-  FLock.BeginRead;
-  {$IFDEF DEBUG}
-  FLockCount.Increment;
-  {$ENDIF DEBUG}
-  Result := FValue;
-end; { Locked<T>.BeginRead }
-
-function Locked<T>.BeginWrite: T;
-begin
-  FLock.BeginWrite;
-  {$IFDEF DEBUG}
-  FLockCount.Increment;
-  {$ENDIF DEBUG}
-  Result := FValue;
-end; { Locked<T>.BeginWrite }
-{$ENDIF OTL_HasLightweightMREW}
 
 procedure Locked<T>.Clear;
 begin
@@ -1857,30 +1599,6 @@ begin
   FValue := Default(T);
   FOwnsObject := false;
 end; { Locked }
-
-{$IFDEF OTL_HasLightweightMREW}
-procedure Locked<T>.EndRead;
-begin
-  FLock.EndRead;
-  {$IFDEF DEBUG}
-  FLockCount.Decrement;
-  {$ENDIF DEBUG}
-end; { Locked<T>.EndRead }
-
-procedure Locked<T>.EndWrite;
-begin
-  FLock.EndWrite;
-  {$IFDEF DEBUG}
-  FLockCount.Decrement;
-  {$ENDIF DEBUG}
-end; { Locked<T>.EndWrite }
-{$ENDIF OTL_HasLightweightMREW}
-
-function Locked<T>.Enter: T;
-begin
-  Acquire;
-  Result := FValue;
-end; { Locked<T>.Enter }
 
 procedure Locked<T>.Free;
 begin
@@ -1900,28 +1618,19 @@ end; { Locked<T>.Free }
 
 function Locked<T>.GetValue: T;
 begin
-  AssertLocked;
+  Assert(FLock.LockCount > 0, 'Locked<T>.GetValue: Not locked');
   Result := FValue;
 end; { Locked<T>.GetValue }
 
 procedure Locked<T>.SetValue(const value: T);
 begin
-  AssertLocked;
+  Assert(FLock.LockCount > 0, 'Locked<T>.SetValue: Not locked');
   FValue := value;
 end; { Locked<T>.SetValue }
 
 function Locked<T>.Initialize(factory: TFactory): T;
 begin
   if not FInitialized then begin
-    {$IFDEF OTL_HasLightweightMREW}
-    FLock := TLightweightMREWExImpl.Create;
-    {$ELSE ~OTL_HasLightweightMREW}
-    FLock.Initialize;
-    {$ENDIF ~OTL_HasLightweightMREW}
-    {$IFDEF DEBUG}
-    FLockCount := CreateCounter;
-    {$ENDIF DEBUG}
-
     Acquire;
     try
       if not FInitialized then begin
@@ -1969,19 +1678,8 @@ begin
       end);
   end;
 end; { Locked<T>.Initialize }
-{$ENDIF OTL_ERTTI}
 
-procedure Locked<T>.Leave;
-begin
-  {$IFDEF OTL_HasLightweightMREW}
-  FLock.EndWrite;
-  {$ELSE ~OTL_HasLightweightMREW}
-  FLock.Release;
-  {$ENDIF ~OTL_HasLightweightMREW}
-  {$IFDEF DEBUG}
-  FLockCount.Decrement;
-  {$ENDIF DEBUG}
-end; { Locked<T>.Leave }
+{$ENDIF OTL_ERTTI}
 
 procedure Locked<T>.Locked(proc: TProc);
 begin
@@ -2001,48 +1699,8 @@ end; { Locked<T>.Locked }
 
 procedure Locked<T>.Release;
 begin
-  Leave;
+  FLock.Release;
 end; { Locked<T>.Release }
-
-{$IFDEF OTL_HasLightweightMREW}
-function Locked<T>.TryBeginRead: boolean;
-begin
-  Result := FLock.TryBeginRead;
-  {$IFDEF DEBUG}
-  if Result then
-    FLockCount.Increment;
-  {$ENDIF DEBUG}
-end; { Locked<T>.TryBeginRead}
-
-function Locked<T>.TryBeginWrite: boolean;
-begin
-  Result := FLock.TryBeginWrite;
-  {$IFDEF DEBUG}
-  if Result then
-    FLockCount.Increment;
-  {$ENDIF DEBUG}
-end; { Locked<T>.TryBeginWrite }
-
-{$IF defined(LINUX) or defined(ANDROID)}
-function Locked<T>.TryBeginRead(timeout: cardinal): boolean;
-begin
-  Result := FLock.TryBeginRead(timeout);
-  {$IFDEF DEBUG}
-  if Result then
-    FLockCount.Increment;
-  {$ENDIF DEBUG}
-end; { Locked<T>.TryBeginRead }
-
-function Locked<T>.TryBeginWrite(timeout: cardinal): boolean; overload; inline;
-begin
-  Result := FLock.TryBeginWrite(timeout);
-  {$IFDEF DEBUG}
-  if Result then
-    FLockCount.Increment;
-  {$ENDIF DEBUG}
-end; { Locked<T>.TryBeginWrite }
-{$IFEND LINUX or ANDROID}
-{$ENDIF OTL_HasLightweightMREW}
 
 {$IFDEF MSWINDOWS}
 
@@ -3034,55 +2692,6 @@ begin
   Result := InterlockedIncrement(Target);
   {$ENDIF OTL_HasTInterlocked}
 end; { TInterlockedEx.Increment }
-
-{$IFDEF OTL_HasLightweightMREW }
-
-{ TLightweightMREWExImpl }
-
-procedure TLightweightMREWExImpl.BeginRead;
-begin
-  FLock.BeginRead;
-end; { TLightweightMREWExImpl.BeginRead }
-
-procedure TLightweightMREWExImpl.BeginWrite;
-begin
-  FLock.BeginWrite;
-end; { TLightweightMREWExImpl.BeginWrite }
-
-procedure TLightweightMREWExImpl.EndRead;
-begin
-  FLock.EndRead;
-end; { TLightweightMREWExImpl.EndRead }
-
-procedure TLightweightMREWExImpl.EndWrite;
-begin
-  FLock.EndWrite;
-end; { TLightweightMREWExImpl.EndWrite }
-
-function TLightweightMREWExImpl.TryBeginRead: boolean;
-begin
-  Result := FLock.TryBeginRead;
-end; { TLightweightMREWExImpl.TryBeginRead }
-
-{$IF defined(LINUX) or defined(ANDROID)}
-function TLightweightMREWExImpl.TryBeginRead(timeout: cardinal): boolean;
-begin
-  Result := FLock.TryBeginRead(timeout);
-end { TLightweightMREWExImpl.TryBeginRead }
-{$IFEND LINUX or ANDROID}
-
-function TLightweightMREWExImpl.TryBeginWrite: boolean;
-begin
-  Result := FLock.TryBeginWrite;
-end; { TLightweightMREWExImpl.TryBeginWrite }
-
-{$IF defined(LINUX) or defined(ANDROID)}
-function TLightweightMREWExImpl.TryBeginWrite(timeout: cardinal): boolean; overload;
-begin
-  Result := FLock.TryBeginWrite(timeout);
-end; { TLightweightMREWExImpl.TryBeginWrite }
-{$IFEND LINUX or ANDROID}
-{$ENDIF OTL_HasLightweightMREW}
 
 initialization
   GOmniCancellationToken := CreateOmniCancellationToken;

--- a/OtlTaskControl.pas
+++ b/OtlTaskControl.pas
@@ -3,7 +3,7 @@
 ///<license>
 ///This software is distributed under the BSD license.
 ///
-///Copyright (c) 2022, Primoz Gabrijelcic
+///Copyright (c) 2021, Primoz Gabrijelcic
 ///All rights reserved.
 ///
 ///Redistribution and use in source and binary forms, with or without modification,
@@ -35,12 +35,10 @@
 ///     Blog            : http://thedelphigeek.com
 ///   Contributors      : GJ, Lee_Nover, Sean B. Durkin, HHasenack
 ///   Creation date     : 2008-06-12
-///   Last modification : 2022-03-08
-///   Version           : 1.43b
+///   Last modification : 2021-06-22
+///   Version           : 1.43a
 ///</para><para>
 ///   History:
-///     1.43b: 2022-03-08
-///       - IOmniTaskGroup.WaitForAll/.TerminateAll no longer crashes if the group is empty.
 ///     1.43a: 2021-06-22
 ///       - Prevent 'nil' handlers to be called from TOmniMessageExec.OnMessage.
 ///     1.43: 2021-03-10
@@ -470,7 +468,7 @@ type
     /// <summary>
     ///   Run the task code from within in the calling thread
     /// </summary>
-    function  DirectExecute: IOmniTaskControl;
+    function  DirectExecute:IOmniTaskControl;
     function  Enforced(forceExecution: boolean = true): IOmniTaskControl;
     function  GetFatalException: Exception;
     function  GetParam: TOmniValueContainer;
@@ -951,18 +949,20 @@ type
     function  GetImplementor: TObject;
     function  GetLock: TSynchroObject;
     function  GetName: string; inline;
-    function  GetOptions: TOmniTaskControlOptions;
     function  GetParam: TOmniValueContainer; inline;
     function  GetTerminateEvent: TOmniTransitionEvent; inline;
     function  GetThreadData: IInterface; inline;
     function  GetUniqueID: int64; inline;
     procedure InternalExecute(calledFromTerminate: boolean);
-    procedure SetOptions(const value: TOmniTaskControlOptions);
     procedure SetThreadData(const value: IInterface); inline;
     procedure Terminate;
   public
     constructor Create(executor: TOmniTaskExecutor; parameters: TOmniValueContainer;
       sharedInfo: TOmniSharedTaskInfo);
+{$ifdef HH_PATCH_InstanceLeakCheck}
+    class function NewInstance:TObject; override;
+    procedure FreeInstance; override;
+{$endif}
     procedure ClearTimer(timerID: integer = 0);
     procedure Enforced(forceExecution: boolean = true);
     procedure Execute;
@@ -997,7 +997,6 @@ type
     property Implementor: TObject read GetImplementor;
     property Lock: TSynchroObject read GetLock;
     property Name: string read GetName;
-    property Options: TOmniTaskControlOptions read GetOptions write SetOptions;
     property Param: TOmniValueContainer read GetParam;
     property SharedInfo: TOmniSharedTaskInfo read otSharedInfo_ref;
     property TerminateEvent: TOmniTransitionEvent read GetTerminateEvent;
@@ -1111,6 +1110,10 @@ type
     constructor Create(worker: TOmniTaskMethod; const taskName: string); overload;
     constructor Create(worker: TOmniTaskProcedure; const taskName: string); overload;
     destructor  Destroy; override;
+{$ifdef HH_PATCH_InstanceLeakCheck}
+    class function NewInstance:TObject; override;
+    procedure FreeInstance; override;
+{$endif}
     function  Alertable: IOmniTaskControl;
     function  CancelWith(const token: IOmniCancellationToken): IOmniTaskControl;
     function  ChainTo(const task: IOmniTaskControl; ignoreErrors: boolean = false): IOmniTaskControl;
@@ -1520,6 +1523,20 @@ begin
   otSharedInfo_ref := sharedInfo;
 end; { TOmniTask.Create }
 
+{$ifdef HH_PATCH_InstanceLeakCheck}
+    class function TOmniTask.NewInstance:TObject;
+    begin
+      Result:=inherited;
+      AddClassRef(self);
+    end;
+
+    procedure TOmniTask.FreeInstance;
+    begin
+      ReleaseClassRef(ClassType);
+      inherited;
+    end;
+{$endif}
+
 procedure TOmniTask.ClearTimer(timerID: integer);
 begin
   SetTimer(timerID, 0, 0);
@@ -1570,11 +1587,6 @@ begin
   else
     Result := '';
 end; { TOmniTask.GetName }
-
-function TOmniTask.GetOptions: TOmniTaskControlOptions;
-begin
-  Result := otExecutor_ref.Options;
-end; { TOmniTask.GetOptions }
 
 function TOmniTask.GetParam: TOmniValueContainer;
 begin
@@ -1715,11 +1727,6 @@ procedure TOmniTask.SetNUMANode(numaNodeNumber: integer);
 begin
   otExecutor_ref.SetNUMANode(numaNodeNumber);
 end; { TOmniTask.SetNUMANode }
-
-procedure TOmniTask.SetOptions(const value: TOmniTaskControlOptions);
-begin
-  otExecutor_ref.Options := value;
-end; { TOmniTask.SetOptions }
 
 procedure TOmniTask.SetProcessorGroup(procGroupNumber: integer);
 begin
@@ -3202,6 +3209,20 @@ begin
   inherited Destroy;
 end; { TOmniTaskControl.Destroy }
 
+{$ifdef HH_PATCH_InstanceLeakCheck}
+    class function TOmniTaskControl.NewInstance:TObject;
+    begin
+      Result:=inherited;
+      AddClassRef(self);
+    end;
+
+    procedure TOmniTaskControl.FreeInstance;
+    begin
+      ReleaseClassRef(ClassType);
+      inherited;
+    end;
+{$endif}
+
 procedure TOmniTaskControl.EnsureCommChannel; //inline
 begin
   if not assigned(otcSharedInfo.CommChannel) then
@@ -4276,11 +4297,6 @@ var
   Idx        : integer;
   {$ENDIF ~MSWINDOWS}
 begin
-  if otgTaskList.Count = 0 then begin
-    Result := true;
-    Exit;
-  end;
-
   {$IFDEF MSWINDOWS}
   SetLength(waitHandles, otgTaskList.Count);
   for iIntf := 0 to otgTaskList.Count - 1 do


### PR DESCRIPTION
Fixed some invalid pointer-to-integer casts,
which especially in OtlTaskCOntrol caused issues with RS13.1 in my own code.